### PR TITLE
Adding type annotation to the argument and return value of fibonacci()

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
This fixes issue #1 where an unsafe 'any' value type is used by assigning a type of 'number' to the argument and return value of fibonacci().