### PR TITLE
Adding type annotation to req and res in fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,13 +1,12 @@
 // Endpoint for querying the fibonacci numbers
-
+import {Request, Response} from 'express';
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req : Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));
   let result = `fibonacci(${num}) is ${fibN}`;
-
   if (fibN < 0) {
     result = `fibonacci(${num}) is undefined`;
   }


### PR DESCRIPTION
Addressing the unsafe 'any' value issue in fibRoute.ts by using type annotation on the req and res variables and importing Request and Response from 'express'